### PR TITLE
Serializer namespace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ The `has_many`, `has_one`, and `belongs_to` declarations describe relationships 
 resources. By default, when you serialize a `Post`, you will get its `Comment`s
 as well.
 
+You may use the `:namespace` options to specify the `Module` where the serializer(s) of an
+association may be found, for example:
+
+```ruby
+  has_many :comments, namespace: Blogging::Serializers
+```
+The serializer used then depends on the class of the object to be serialized e.g. if a
+comment is an instance of class `AdminComment`, the serializer would use
+`Blogging::Serializers::AdminComment` to serializer this comment.
+
 You may also use the `:serializer` option to specify a custom serializer class, for example:
 
 ```ruby
@@ -263,6 +273,20 @@ You may also use the `:serializer` option to specify a custom serializer class, 
 
 The `url` declaration describes which named routes to use while generating URLs
 for your JSON. Not every adapter will require URLs.
+
+## Array serializer
+When calling the `ActiveModel::Serializer::ArraySerializer#new`, you may pass the `:namespace`
+to specify the module in which the objects serializers may be found. The serializers used then
+depend on the objects class.
+
+Take the example below:
+
+```ruby
+a = [Post.new,AdminComment.new]
+ActiveRecord::Serializer.ArraySerializer.new(a, namespace: Blogging::Serializers)
+```
+Here the objects of `a` would respectively be serialized using `Blogging::Serializers::Post`
+and `Blogging::Serializers::AdminComment.`
 
 ## Caching
 

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -212,7 +212,13 @@ module ActiveModel
     end
 
     def serializer_from_options(options)
-      options.fetch(:association_options, {}).select { |key, value| [:serializer,:namespace].include?(key) }
+      opts = {}
+      association_options = options.fetch(:association_options, {})
+      [:serializer,:namespace].each do |key|
+        value = association_options.fetch(key, nil)
+        opts[key] = value if value
+      end
+      opts
     end
 
     def self.serializers_cache

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -105,9 +105,14 @@ module ActiveModel
       if resource.respond_to?(:to_ary)
         config.array_serializer
       else
-        options
-          .fetch(:association_options, {})
-          .fetch(:serializer, get_serializer_for(resource.class))
+        resource_class = resource.class
+        association_options = options.fetch(:association_options, {})
+        namespace = options[:namespace] || association_options[:namespace]
+        if namespace
+          "#{namespace}::#{resource_class.name.demodulize}".safe_constantize
+        else
+          association_options.fetch(:serializer, get_serializer_for(resource_class))
+        end
       end
     end
 
@@ -207,10 +212,7 @@ module ActiveModel
     end
 
     def serializer_from_options(options)
-      opts = {}
-      serializer = options.fetch(:association_options, {}).fetch(:serializer, nil)
-      opts[:serializer] = serializer if serializer
-      opts
+      options.fetch(:association_options, {}).select { |key, value| [:serializer,:namespace].include?(key) }
     end
 
     def self.serializers_cache

--- a/lib/active_model/serializer/array_serializer.rb
+++ b/lib/active_model/serializer/array_serializer.rb
@@ -8,11 +8,10 @@ module ActiveModel
 
       def initialize(objects, options = {})
         options.merge!(root: nil)
-
         @objects = objects.map do |object|
           serializer_class = options.fetch(
             :serializer,
-            ActiveModel::Serializer.serializer_for(object)
+            ActiveModel::Serializer.serializer_for(object, options)
           )
           serializer_class.new(object, options)
         end

--- a/test/array_serializer_test.rb
+++ b/test/array_serializer_test.rb
@@ -24,6 +24,18 @@ module ActiveModel
 
         assert_equal serializers.last.custom_options[:some], :options
       end
+
+      def test_each_object_should_be_serialized_with_appropriate_serializer
+        array = [Post.new, Post.new]
+        @serializer = ArraySerializer.new([@comment, @post], {namespace: Test::Serializer})
+        serializers =  @serializer.to_a
+
+        assert_kind_of Test::Serializer::Comment, serializers.first
+        assert_kind_of Comment, serializers.first.object
+
+        assert_kind_of Test::Serializer::Post, serializers.last
+        assert_kind_of Post, serializers.last.object
+      end
     end
   end
 end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -171,3 +171,19 @@ end
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do
   attributes :id
 end
+
+module Test
+  module Serializer
+    Post = Class.new(ActiveModel::Serializer) do
+      attributes :id, :title
+
+      has_many :comments, namespace: Test::Serializer
+    end
+
+    Comment = Class.new(ActiveModel::Serializer) do
+      attributes :id
+
+      belongs_to :post, namespace: Test::Serializer
+    end
+  end
+end

--- a/test/serializers/associations_test.rb
+++ b/test/serializers/associations_test.rb
@@ -73,6 +73,13 @@ module ActiveModel
         end
       end
 
+      def test_association_with_namespace_options_uses_namespace_serializer
+        @post_serializer = Test::Serializer::Post.new(@post)
+        @post_serializer.each_association do |name, serializer, options|
+          assert_kind_of Test::Serializer::Comment, serializer.to_a.first
+        end
+      end
+
       def test_belongs_to
         assert_equal(
           { post: { type: :belongs_to, association_options: {} },

--- a/test/serializers/serializer_for_test.rb
+++ b/test/serializers/serializer_for_test.rb
@@ -50,6 +50,12 @@ module ActiveModel
           serializer = ActiveModel::Serializer.serializer_for(@my_profile)
           assert_equal ProfileSerializer, serializer
         end
+
+        def test_serializer_in_module
+          post = Post.new
+          serializer = ActiveModel::Serializer.serializer_for(post, { namespace: Test::Serializer })
+          assert_equal Test::Serializer::Post, serializer
+        end
       end
     end
   end


### PR DESCRIPTION
Added a `:namespace` option to serializer association and `ArraySerializer` to specify which module contains the serializers to be used.
