### PR TITLE
Duplicated objects in data and included can now be removed

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -57,6 +57,7 @@ module ActiveModel
               id   = included[:id]
               not_in_data?(ids_per_type, type, id)
             end
+            hash.delete(:included) if hash[:included].empty?
           end
           hash
         end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -318,6 +318,19 @@ module ActiveModel
             ]
             assert_equal expected, adapter.serializable_hash[:included]
           end
+
+
+          def test_no_included_after_duplication_removal
+            @first_post.comments = [@first_comment]
+            serializer = ArraySerializer.new([@first_post, @first_comment])
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(
+              serializer,
+              include: ['comments'],
+              prevent_duplicates: true
+            )
+
+            assert_equal false, adapter.serializable_hash.has_key?(:included)
+          end
         end
       end
     end


### PR DESCRIPTION
I addded a `:prevent_duplicates` option to the json api serializer which remove all the duplicated data when it is set to `true`.
