### PR TITLE
Add JSON API link urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,40 @@ resources in the `"included"` member when the resource names are included in the
   render @posts, include: 'authors,comments'
 ```
 
+Link urls can be defined by adding methods with specific name to the serializer. For example,
+```ruby
+class PostSerializer < ActiveModel::Serializer
+  has_many :comments
+
+  def self_link
+    "http://foo.com/posts/#{object.id}"
+  end
+  def comments_self_link # association name followed by "_self_link"
+    "http://bar.com/posts/#{object.id}/comments",
+  end
+  def comments_related_link # association name followed by "_related_link"
+    "http://api.foo.com/posts/#{object.id}/rel/comments",
+  end
+end
+
+```
+may result as
+```json
+{
+  "id": "1",
+  "type": "posts",
+  "self": "http://foo.com/posts/1",
+  "links": {
+    "comments": {
+      "self": "http://bar.com/posts/1/comments",
+      "related": "http://api.foo.com/posts/1/rel/comments",
+      "linkage": [{ "id": 5, "type": "comments" }]
+    }
+  }
+}
+```
+
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -88,7 +88,6 @@ module ActiveModel
             object.send attr
           end
         end
-
         self._associations[attr] = {type: type, association_options: options}
       end
     end

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -1,0 +1,138 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi
+        class LinksTest < Minitest::Test
+          class CommentWithLinkSerializer < ActiveModel::Serializer
+            def self_link
+              "http://fake.com/comments/#{object.id}"
+            end
+          end
+
+          class CommentWithNilLinkSerializer < ActiveModel::Serializer
+            def self_link
+              nil
+            end
+          end
+
+          class PostWithLinksSerializer < ActiveModel::Serializer
+            attribute :title
+            has_many :comments, serializer: CommentWithLinkSerializer
+
+            def comments_self_link
+              "http://fake.com/posts/#{object.id}/comments"
+            end
+
+            def comments_related_link
+              "http://fake.com/posts/#{object.id}/rel/comments"
+            end
+          end
+
+          class PostWithNilLinksSerializer < ActiveModel::Serializer
+            attribute :title
+            has_many :comments, serializer: CommentWithNilLinkSerializer
+
+            def comments_self_link
+              nil
+            end
+
+            def comments_related_link
+              nil
+            end
+          end
+
+
+          def setup
+            @post = Post.new(id: 1, title: 'Hello!!', body: 'Hello, world!!', comments: [])
+            @comment = Comment.new(id: 5)
+            ActionController::Base.cache_store.clear
+          end
+
+          def test_self_link
+            expected = {
+              data: {
+                id: "5",
+                type: "comments",
+                links: {
+                  self: "http://fake.com/comments/5"
+                }
+              }
+            }
+            assert_serialization(CommentWithLinkSerializer, @comment, expected)
+          end
+
+          def test_nil_self_link
+            expected = {
+              data: {
+                id: "5",
+                type: "comments"
+              }
+            }
+            assert_serialization(CommentWithNilLinkSerializer, @comment, expected)
+          end
+
+          def test_association_links
+            @post.comments = [@comment]
+            expected = {
+              data: {
+                id: "1",
+                type: "posts",
+                title: "Hello!!",
+                links: {
+                  comments: {
+                    self: "http://fake.com/posts/1/comments",
+                    related: "http://fake.com/posts/1/rel/comments",
+                    linkage: [{ id: "5", type: "comments" }]
+                  }
+                }
+              },
+              included: [
+                {
+                   id: "5",
+                   type: "comments",
+                   links: {
+                     self: "http://fake.com/comments/5",
+                   }
+                }
+              ]
+            }
+            assert_serialization(PostWithLinksSerializer, @post, expected, { include: "comments" })
+          end
+
+          def test_nil_association_links
+            @post.comments = [@comment]
+            expected = {
+              data: {
+                id: "1",
+                type: "posts",
+                title: "Hello!!",
+                links: {
+                  comments: {
+                    linkage: [{ id: "5", type: "comments" }]
+                  }
+                }
+              },
+              included: [
+                {
+                   id: "5",
+                   type: "comments"
+                }
+              ]
+            }
+            assert_serialization(PostWithNilLinksSerializer, @post, expected, { include: "comments" })
+          end
+
+          private
+
+          def assert_serialization(serializer_class, object, expected, options = {})
+            serializer = serializer_class.new(object)
+            adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, options)
+            assert_equal(expected, adapter.serializable_hash)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added `self` url feature for main resources and `self` and `related` url feature for associations when using JSON API adapter.
