### PR TITLE
Added a :allow_blank_linkage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ resources in the `"included"` member when the resource names are included in the
   render @posts, include: 'authors,comments'
 ```
 
+##### Linkage
+An `allow_blank_linkage` option is available for the JSON API adapter and can be set
+to `false` in order to remove nil/empty linkages.
+
+```ruby
+ActiveModel::Serializer::Adapter::JsonApi.new(serializer, allow_blank_linkage: false)
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/active_model/serializer/adapter/json_api/configuration.rb
+++ b/lib/active_model/serializer/adapter/json_api/configuration.rb
@@ -1,0 +1,16 @@
+module ActiveModel
+  class Serializer
+    class Adapter
+      class JsonApi < Adapter
+        module Configuration
+          include ActiveSupport::Configurable
+          extend ActiveSupport::Concern
+
+          included do |base|
+            base.config.default_options = { include_blank_linkage: true }
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -30,13 +30,29 @@ module ActiveModel
 
             @serializer = PostSerializer.new(@post)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer)
+            ActionController::Base.cache_store.clear
           end
 
-          def test_includes_comment_ids
+          def test_includes_comments_linkage
             expected = { linkage: [ { type: "comments", id: "1" }, { type: "comments", id: "2" } ] }
 
             assert_equal(expected, @adapter.serializable_hash[:data][:links][:comments])
           end
+
+          def test_includes_empty_comments_linkage
+            @post.comments = []
+            expected = { linkage: [] }
+
+            assert_equal(expected, @adapter.serializable_hash[:data][:links][:comments])
+          end
+
+          def test_allow_blank_linkage_option_set_to_false
+            @post.comments = []
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts', include_blank_linkage: false)
+
+            refute @adapter.serializable_hash[:data][:links].key?(:comments)
+          end
+
 
           def test_includes_linked_comments
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments')

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -27,12 +27,27 @@ module ActiveModel
 
             @serializer = AuthorSerializer.new(@author)
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts')
+            ActionController::Base.cache_store.clear
           end
 
-          def test_includes_bio_id
+          def test_includes_bio_linkage
             expected = { linkage: { type: "bios", id: "43" } }
 
             assert_equal(expected, @adapter.serializable_hash[:data][:links][:bio])
+          end
+
+          def test_includes_nil_bio_linkage
+            @author.bio = nil
+            expected = { linkage: nil }
+
+            assert_equal(expected, @adapter.serializable_hash[:data][:links][:bio])
+          end
+
+          def test_allow_blank_linkage_option_set_to_false
+            @author.bio = nil
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts', include_blank_linkage: false)
+
+            refute @adapter.serializable_hash[:data][:links].key?(:bio)
           end
 
           def test_includes_linked_bio


### PR DESCRIPTION
This option allow us to remove nil/empty linkage when using json api adapter.
