### PR TITLE
Fixed readme and tests for include_blank_linkage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,16 @@ resources in the `"included"` member when the resource names are included in the
 ```
 
 ##### Linkage
-An `allow_blank_linkage` option is available for the JSON API adapter and can be set
+An `include_blank_linkage` option is available for the JSON API adapter and can be set
 to `false` in order to remove nil/empty linkages.
 
+You can do it as a global config:
+```ruby
+ActiveModel::Serializer::Adapter::JsonApi.config.default_options = {
+  include_blank_linkage: false
+}
+```
+or for each individual serialization:
 ```ruby
 ActiveModel::Serializer::Adapter::JsonApi.new(serializer, allow_blank_linkage: false)
 ```

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -7,7 +7,7 @@ module ActiveModel
 
         def initialize(serializer, options = {})
           super
-          @options = config.default_options.merge(@options)
+          @options.reverse_merge!(config.default_options)
 
           serializer.root = true
           @hash = { data: [] }

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -48,11 +48,23 @@ module ActiveModel
 
           def test_allow_blank_linkage_option_set_to_false
             @post.comments = []
-            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts', include_blank_linkage: false)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include_blank_linkage: false)
 
             refute @adapter.serializable_hash[:data][:links].key?(:comments)
           end
 
+          def test_allow_blank_linkage_config
+            config = ActiveModel::Serializer::Adapter::JsonApi.config
+            default_options = config.default_options
+            config.default_options = { include_blank_linkage: false }
+
+            @post.comments = []
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts')
+
+            refute @adapter.serializable_hash[:data][:links].key?(:comments)
+
+            config.default_options = default_options
+          end
 
           def test_includes_linked_comments
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments')

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -45,9 +45,22 @@ module ActiveModel
 
           def test_allow_blank_linkage_option_set_to_false
             @author.bio = nil
-            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts', include_blank_linkage: false)
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include_blank_linkage: false)
 
             refute @adapter.serializable_hash[:data][:links].key?(:bio)
+          end
+
+          def test_allow_blank_linkage_config
+            config = ActiveModel::Serializer::Adapter::JsonApi.config
+            default_options = config.default_options
+            config.default_options = { include_blank_linkage: false }
+
+            @author.bio = nil
+            @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio,posts')
+
+            refute @adapter.serializable_hash[:data][:links].key?(:bio)
+
+            config.default_options = default_options
           end
 
           def test_includes_linked_bio


### PR DESCRIPTION
The README contained a wrong snippet which is now correct.
Specs for the json api adapter config were added.
