### PR TITLE
Result collections are array instead of set due to incompatibility issues

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -23,6 +23,8 @@ module ActiveModel
         def serializable_hash(options = {})
           serializable_hash_with_duplicates
           remove_duplicates
+          @hash[:data]     = @hash[:data].to_a if serializer.respond_to?(:each)
+          @hash[:included] = @hash[:included].to_a if @hash.key?(:included)
           @hash
         end
 

--- a/test/adapter/json_api/belongs_to_test.rb
+++ b/test/adapter/json_api/belongs_to_test.rb
@@ -39,7 +39,7 @@ module ActiveModel
 
           def test_includes_linked_post
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'post')
-            expected = Set.new([{
+            expected = [{
               id: "42",
               type: "posts",
               attributes: {
@@ -51,13 +51,13 @@ module ActiveModel
                 blog: { data: { type: "blogs", id: "999" } },
                 author: { data: { type: "authors", id: "1" } }
               }
-            }])
+            }]
             assert_equal expected, @adapter.serializable_hash[:included]
           end
 
           def test_limiting_linked_post_fields
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'post', fields: {post: [:title]})
-            expected = Set.new([{
+            expected = [{
               id: "42",
               type: "posts",
               attributes: {
@@ -68,7 +68,7 @@ module ActiveModel
                 blog: { data: { type: "blogs", id: "999" } },
                 author: { data: { type: "authors", id: "1" } }
               }
-            }])
+            }]
             assert_equal expected, @adapter.serializable_hash[:included]
           end
 
@@ -110,7 +110,7 @@ module ActiveModel
             serializer = BlogSerializer.new(@blog)
             adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: ['writer', 'articles'])
             linked = adapter.serializable_hash[:included]
-            expected = Set.new([
+            expected = [
               {
                 id: "1",
                 type: "authors",
@@ -147,7 +147,7 @@ module ActiveModel
                   author: { data: nil }
                 }
               }
-            ])
+            ]
             assert_equal expected, linked
           end
         end

--- a/test/adapter/json_api/collection_test.rb
+++ b/test/adapter/json_api/collection_test.rb
@@ -25,7 +25,7 @@ module ActiveModel
           end
 
           def test_include_multiple_posts
-            expected = Set.new([
+            expected = [
               {
                 id: "1",
                 type: "posts",
@@ -52,7 +52,7 @@ module ActiveModel
                   author: { data: { type: "authors", id: "1" } }
                 }
               }
-            ])
+            ]
 
             assert_equal(expected, @adapter.serializable_hash[:data])
           end
@@ -60,7 +60,7 @@ module ActiveModel
           def test_limiting_fields
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, fields: ['title'])
 
-            expected = Set.new([
+            expected = [
               {
                 id: "1",
                 type: "posts",
@@ -85,7 +85,7 @@ module ActiveModel
                   author: { data: { type: "authors", id: "1" } }
                 }
               }
-            ])
+            ]
             assert_equal(expected, @adapter.serializable_hash[:data])
           end
 

--- a/test/adapter/json_api/has_many_explicit_serializer_test.rb
+++ b/test/adapter/json_api/has_many_explicit_serializer_test.rb
@@ -41,7 +41,7 @@ module ActiveModel
 
           def test_includes_linked_data
             # If CommentPreviewSerializer is applied correctly the body text will not be present in the output
-            expected = Set.new([
+            expected = [
               {
                 id: '1',
                 type: 'comments',
@@ -63,7 +63,7 @@ module ActiveModel
                   posts: { data: [ {type: "posts", id: @post.id.to_s } ] }
                 }
               }
-            ])
+            ]
 
             assert_equal(expected, @adapter.serializable_hash[:included])
           end

--- a/test/adapter/json_api/has_many_test.rb
+++ b/test/adapter/json_api/has_many_test.rb
@@ -53,7 +53,7 @@ module ActiveModel
 
           def test_includes_linked_comments
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments')
-            expected = Set.new([{
+            expected = [{
               id: "1",
               type: "comments",
               attributes: {
@@ -73,13 +73,13 @@ module ActiveModel
                 post: { data: { type: "posts", id: "1" } },
                 author: { data: nil }
               }
-            }])
+            }]
             assert_equal expected, @adapter.serializable_hash[:included]
           end
 
           def test_limit_fields_of_linked_comments
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'comments', fields: {comment: [:id]})
-            expected = Set.new([{
+            expected = [{
               id: "1",
               type: "comments",
               relationships: {
@@ -93,7 +93,7 @@ module ActiveModel
                 post: { data: { type: "posts", id: "1" } },
                 author: { data: nil }
               }
-            }])
+            }]
             assert_equal expected, @adapter.serializable_hash[:included]
           end
 

--- a/test/adapter/json_api/has_one_test.rb
+++ b/test/adapter/json_api/has_one_test.rb
@@ -65,7 +65,7 @@ module ActiveModel
           def test_includes_linked_bio
             @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(@serializer, include: 'bio')
 
-            expected = Set.new([
+            expected = [
               {
                 id: "43",
                 type: "bios",
@@ -77,7 +77,7 @@ module ActiveModel
                   author: { data: { type: "authors", id: "1" } }
                 }
               }
-            ])
+            ]
 
             assert_equal(expected, @adapter.serializable_hash[:included])
           end

--- a/test/adapter/json_api/linked_test.rb
+++ b/test/adapter/json_api/linked_test.rb
@@ -51,7 +51,7 @@ module ActiveModel
             )
 
             expected = {
-              data: Set.new([
+              data: [
                 {
                   id: "10",
                   type: "posts",
@@ -78,8 +78,8 @@ module ActiveModel
                     author: { data: { type: "authors", id: "2" } }
                   }
                 }
-              ]),
-              included: Set.new([
+              ],
+              included: [
                 {
                   id: "1",
                   type: "comments",
@@ -143,7 +143,7 @@ module ActiveModel
                     author: { data: { type: "authors", id: "2" } }
                   }
                 }
-              ])
+              ]
             }
             assert_equal expected, adapter.serializable_hash
             assert_equal expected, alt_adapter.serializable_hash
@@ -160,7 +160,7 @@ module ActiveModel
               include: 'author,author.posts'
             )
 
-            expected = Set.new([
+            expected = [
               {
                 id: "1",
                 type: "authors",
@@ -197,7 +197,7 @@ module ActiveModel
                   author: { data: { type: "authors", id: "1" } }
                 }
               }
-            ])
+            ]
 
             assert_equal expected, adapter.serializable_hash[:included]
             assert_equal expected, alt_adapter.serializable_hash[:included]
@@ -227,7 +227,7 @@ module ActiveModel
               include: ['post']
             )
 
-            expected = Set.new([
+            expected = [
               {
                 id: "10",
                 type: "posts",
@@ -247,7 +247,7 @@ module ActiveModel
                   }
                 }
               }
-            ])
+            ]
 
             assert_equal expected, adapter.serializable_hash[:included]
           end
@@ -284,7 +284,7 @@ module ActiveModel
               include: ['author', 'comments']
             )
 
-            expected = Set.new([
+            expected = [
               {
                 id:"1",
                 attributes: { body:"ZOMG A COMMENT" },
@@ -311,7 +311,7 @@ module ActiveModel
                   bio: { data: { type: "bios", id: "1" } }
                 }
               }
-            ])
+            ]
             assert_equal expected, adapter.serializable_hash[:included]
           end
 
@@ -323,7 +323,7 @@ module ActiveModel
               prevent_duplicates: true
             )
 
-            expected = Set.new([
+            expected = [
               {
                 id: "2",
                 attributes: { body: "ZOMG ANOTHER COMMENT" },
@@ -342,7 +342,7 @@ module ActiveModel
                   bio: { data: { type: "bios", id: "1" } }
                 }
               }
-            ])
+            ]
             assert_equal expected, adapter.serializable_hash[:included]
           end
 


### PR DESCRIPTION
Sets don't work well with active support so we changed the result `data` and `included` to an array before returning it.
