### PR TITLE
Add `links` to response for serializers that respond to `json_api_links`

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -50,6 +50,7 @@ module ActiveModel
           else
             @hash[:data] = attributes_for_serializer(serializer, @options)
             add_resource_relationships(@hash[:data], serializer)
+            add_links(@hash[:data], serializer)
             @hash
           end
         end
@@ -97,6 +98,7 @@ module ActiveModel
               attrs = attributes_for_serializer(serializer, @options)
 
               add_resource_relationships(attrs, serializer, add_included: false)
+              add_links(attrs, serializer)
 
               @hash[:included] << attrs unless @hash[:included].include?(attrs)
             end
@@ -178,6 +180,11 @@ module ActiveModel
               end
             end
           end
+        end
+
+        def add_links(attrs, serializer)
+          return unless serializer.respond_to?(:json_api_links)
+          attrs.merge!(links: serializer.json_api_links)
         end
       end
     end

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class LinksTest < Minitest::Test
+
+      def setup
+        ActionController::Base.cache_store.clear
+        @sitemap = Sitemap.new(id: "1909", title: 'New Post')
+        @page = Page.new(id: "1515", title: "foo", href: "https://d2z0k43lzfi12d.cloudfront.net/blog/wp-content/uploads/2015/09/09_02_Teamphoto-e1441186058964.jpg")
+        @sitemap.pages = [@page]
+      end
+
+      def test_links_in_included
+        expected = {
+          :data => {
+            :id => "1909",
+            :type => "sitemaps",
+            :relationships => {
+              :pages => {
+                :data => [
+                  {
+                    :type => "pages",
+                    :id => "1515"
+                  }
+                ]
+              }
+            }
+          },
+          :included => [
+            {
+              :id => "1515",
+              :type => "pages",
+              :links => {
+                :self => "https://d2z0k43lzfi12d.cloudfront.net/blog/wp-content/uploads/2015/09/09_02_Teamphoto-e1441186058964.jpg"
+              }
+            }
+          ]
+        }
+        serializer = ::SitemapSerializer.new(@sitemap)
+        @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: "pages")
+
+        assert_equal(expected, @adapter.serializable_hash)
+      end
+
+      def test_links_in_data
+        expected = {
+          :data => {
+            :id => "1515",
+            :type => "pages",
+            :links => {
+              :self => "https://d2z0k43lzfi12d.cloudfront.net/blog/wp-content/uploads/2015/09/09_02_Teamphoto-e1441186058964.jpg"
+            }
+          }
+        }
+
+        serializer = PageSerializer.new(@page)
+        @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+
+        assert_equal(expected, @adapter.serializable_hash)
+      end
+    end
+  end
+end

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -83,6 +83,8 @@ Role     = Class.new(Model)
 User     = Class.new(Model)
 Location = Class.new(Model)
 Place    = Class.new(Model)
+Page     = Class.new(Model)
+Sitemap  = Class.new(Model)
 
 module Spam; end
 Spam::UnrelatedLink = Class.new(Model)
@@ -223,6 +225,16 @@ PostPreviewSerializer = Class.new(ActiveModel::Serializer) do
 
   has_many :comments, serializer: CommentPreviewSerializer
   belongs_to :author, serializer: AuthorPreviewSerializer
+end
+
+PageSerializer = Class.new(ActiveModel::Serializer) do
+  def json_api_links
+    { self: object.href }
+  end
+end
+
+SitemapSerializer = Class.new(ActiveModel::Serializer) do
+  has_many :pages, serializer: PageSerializer
 end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do


### PR DESCRIPTION
Adds `links` for serializers that respond to `json_api_links` creating a structure like this:

```
{
  data:  { 
    attributes: {}, 
    relationships: {}, 
    links: {
      self: "uri”
    }
  },
  included: [
    {
      id: "abcd-1234",
      type: "entity",
      links: {
        self: "uri"
      }
    }
  ]
}
```
