### PR TITLE
Add optional jsonapi parameter to serializer

### DIFF
--- a/lib/active_model/serializer.rb
+++ b/lib/active_model/serializer.rb
@@ -155,7 +155,7 @@ module ActiveModel
       name.demodulize.underscore.sub(/_serializer$/, '') if name
     end
 
-    attr_accessor :object, :root, :meta, :meta_key, :scope
+    attr_accessor :object, :root, :meta, :meta_key, :scope, :jsonapi
 
     def initialize(object, options = {})
       @object     = object
@@ -164,6 +164,7 @@ module ActiveModel
       @meta       = options[:meta]
       @meta_key   = options[:meta_key]
       @scope      = options[:scope]
+      @jsonapi    = options[:jsonapi]
 
       scope_name = options[:scope_name]
       if scope_name && !respond_to?(scope_name)

--- a/lib/active_model/serializer/adapter.rb
+++ b/lib/active_model/serializer/adapter.rb
@@ -22,7 +22,8 @@ module ActiveModel
 
       def as_json(options = {})
         hash = serializable_hash(options)
-        include_meta(hash) unless self.class == FlattenJson
+        include_meta(hash)    unless self.class == FlattenJson
+        include_jsonapi(hash) unless self.class == FlattenJson
         hash
       end
 
@@ -85,6 +86,15 @@ module ActiveModel
 
       def root
         serializer.json_key.to_sym if serializer.json_key
+      end
+
+      def jsonapi
+        serializer.jsonapi if serializer.respond_to?(:jsonapi)
+      end
+
+      def include_jsonapi(json)
+        json[:jsonapi] = jsonapi if jsonapi
+        json
       end
 
       def include_meta(json)

--- a/test/serializers/jsonapi_test.rb
+++ b/test/serializers/jsonapi_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module ActiveModel
+  class Serializer
+    class JsonApiTest < Minitest::Test
+      def setup
+        ActionController::Base.cache_store.clear
+        @blog = Blog.new(id: 1,
+                         name: 'AMS Hints',
+                         writer: Author.new(id: 2, name: "Steve"),
+                         articles: [Post.new(id: 3, title: "AMS")])
+      end
+
+      def test_jsonapi
+        serializer = AlternateBlogSerializer.new(@blog, jsonapi: { version: "1.0" })
+        adapter = ActiveModel::Serializer::Adapter::Json.new(serializer, root: 'blog')
+        expected = {
+          alternate_blog: {
+            id: 1,
+            title: "AMS Hints"
+          },
+          jsonapi: {
+            version: "1.0"
+          }
+        }
+        assert_equal expected, adapter.as_json
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
To be able to pass something in for jsonapi, like: http://jsonapi.org/format/#document-jsonapi-object
