### PR TITLE
Pass parent serializer to relationship_links

### DIFF
--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -38,7 +38,7 @@ module ActiveModel
 
         def serializable_hash_with_duplicates
           if serializer.respond_to?(:each)
-            
+
             serializer.each do |s|
               result = self.class.new(s, @options.merge(fieldset: @fieldset)).serializable_hash_with_duplicates
               @hash[:data] << result[:data]
@@ -176,13 +176,9 @@ module ActiveModel
                 add_relationship(attrs, name, association)
               end
             end
-          
-            add_relationship_meta(attrs[:relationships][name], serializer, opts[:meta])
 
-            if association.respond_to?(:relationship_links) &&
-              @options[:include].include?(name.to_s)
-              add_relationship_links(attrs[:relationships][name], association)
-            end
+            add_relationship_meta(attrs[:relationships][name], serializer, opts[:meta])
+            add_relationship_links(attrs[:relationships][name], serializer, association)
 
             if options[:add_included]
               Array(association).each do |association|
@@ -191,10 +187,10 @@ module ActiveModel
             end
           end
         end
-        
-        def add_relationship_links(attrs, serializer)
-          return unless serializer.respond_to?(:relationship_links)
-          attrs.merge!(links: serializer.relationship_links)
+
+        def add_relationship_links(attrs, serializer, association_serializer)
+          return unless association_serializer.respond_to?(:relationship_links)
+          attrs.merge!(links: association_serializer.relationship_links(serializer))
         end
 
         def add_resource_links(attrs, serializer)

--- a/lib/active_model/serializer/adapter/json_api.rb
+++ b/lib/active_model/serializer/adapter/json_api.rb
@@ -178,7 +178,7 @@ module ActiveModel
             end
 
             add_relationship_meta(attrs[:relationships][name], serializer, opts[:meta])
-            add_relationship_links(attrs[:relationships][name], serializer, association)
+            add_relationship_links(attrs[:relationships][name], name, serializer, association)
 
             if options[:add_included]
               Array(association).each do |association|
@@ -188,9 +188,10 @@ module ActiveModel
           end
         end
 
-        def add_relationship_links(attrs, serializer, association_serializer)
+        def add_relationship_links(attrs, name, serializer, association_serializer)
           return unless association_serializer.respond_to?(:relationship_links)
-          attrs.merge!(links: association_serializer.relationship_links(serializer))
+          links = association_serializer.relationship_links(name, serializer)
+          attrs.merge!(links: links)
         end
 
         def add_resource_links(attrs, serializer)

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -8,7 +8,7 @@ module ActiveModel
         ActionController::Base.cache_store.clear
         @sitemap = Sitemap.new(id: "1909", title: 'New Post')
         @page = Page.new(id: "1515", title: "foo", href: "https://d2z0k43lzfi12d.cloudfront.net/blog/wp-content/uploads/2015/09/09_02_Teamphoto-e1441186058964.jpg")
-        @sitemap.pages = [@page]
+        @sitemap.page = @page
       end
 
       def test_links_in_included
@@ -17,13 +17,12 @@ module ActiveModel
             :id => "1909",
             :type => "sitemaps",
             :relationships => {
-              :pages => {
-                :data => [
-                  {
-                    :type => "pages",
-                    :id => "1515"
-                  }
-                ]
+              :page => {
+                :data => {
+                  :type => "pages",
+                  :id => "1515"
+                },
+                :links=>{:self=>"/sitemap/1909/page/1515"}
               }
             }
           },
@@ -38,7 +37,7 @@ module ActiveModel
           ]
         }
         serializer = ::SitemapSerializer.new(@sitemap)
-        @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: "pages")
+        @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer, include: "page")
 
         assert_equal(expected, @adapter.serializable_hash)
       end

--- a/test/adapter/json_api/links_test.rb
+++ b/test/adapter/json_api/links_test.rb
@@ -11,6 +11,28 @@ module ActiveModel
         @sitemap.page = @page
       end
 
+      def test_relationship_links
+        expected = {
+          :data => {
+            :id => "1909",
+            :type => "sitemaps",
+            :relationships => {
+              :page => {
+                :data => {
+                  :type => "pages",
+                  :id => "1515"
+                },
+                :links=>{:self=>"/sitemap/1909/page/1515/page"}
+              }
+            }
+          }
+        }
+        serializer = ::SitemapSerializer.new(@sitemap)
+        @adapter = ActiveModel::Serializer::Adapter::JsonApi.new(serializer)
+
+        assert_equal(expected, @adapter.serializable_hash)
+      end
+      
       def test_links_in_included
         expected = {
           :data => {
@@ -22,7 +44,7 @@ module ActiveModel
                   :type => "pages",
                   :id => "1515"
                 },
-                :links=>{:self=>"/sitemap/1909/page/1515"}
+                :links=>{:self=>"/sitemap/1909/page/1515/page"}
               }
             }
           },

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -232,8 +232,8 @@ PageSerializer = Class.new(ActiveModel::Serializer) do
     { self: object.href }
   end
 
-  def relationship_links(parent_serializer)
-    { self: "/sitemap/#{parent_serializer.object.id}/page/#{object.id}" }
+  def relationship_links(name, parent_serializer)
+    { self: "/sitemap/#{parent_serializer.object.id}/page/#{object.id}/#{name}" }
   end
 end
 

--- a/test/fixtures/poro.rb
+++ b/test/fixtures/poro.rb
@@ -231,6 +231,10 @@ PageSerializer = Class.new(ActiveModel::Serializer) do
   def resource_links
     { self: object.href }
   end
+
+  def relationship_links(parent_serializer)
+    { self: "/sitemap/#{parent_serializer.object.id}/page/#{object.id}" }
+  end
 end
 
 PageMetaSerializer = Class.new(ActiveModel::Serializer) do
@@ -266,7 +270,7 @@ ProcMetaPostSerializer = Class.new(ActiveModel::Serializer) do
 end
 
 SitemapSerializer = Class.new(ActiveModel::Serializer) do
-  has_many :pages, serializer: PageSerializer
+  has_one :page, serializer: PageSerializer
 end
 
 Spam::UnrelatedLinkSerializer = Class.new(ActiveModel::Serializer) do


### PR DESCRIPTION
The `relationship_links` method now receive the parent serializer so that it can be used within the links.
